### PR TITLE
Switch to node slim images for 80% smaller container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM docker.io/node:16 as base
 
+ENV NODE_ENV=local
 RUN mkdir /app && chown node:node /app
 
 USER node
@@ -15,13 +16,14 @@ RUN npm run build
 
 FROM docker.io/node:16-slim as prod
 
+ENV NODE_ENV=production
 RUN mkdir /app && chown node:node /app
 
 USER node
 
 WORKDIR /app
 COPY --chown=node:node package*.json .
-RUN npm ci --production && npm cache clean --force
+RUN npm ci && npm cache clean --force
 COPY --chown=node:node --from=build /app/dist/ .
 
 CMD ["npm", "run", "prod"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM docker.io/node:16 as base
 
-RUN mkdir /app
-RUN chown node:node /app
+RUN mkdir /app && chown node:node /app
 
 USER node
 
@@ -16,8 +15,7 @@ RUN npm run build
 
 FROM docker.io/node:16-slim as prod
 
-RUN mkdir /app
-RUN chown node:node /app
+RUN mkdir /app && chown node:node /app
 
 USER node
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,9 @@ COPY --chown=node:node package*.json .
 RUN npm ci && npm cache clean --force
 COPY --chown=node:node . .
 
-CMD npx knex migrate:latest && \
-    npx ts-node src/deploy-commands.ts && \
-    exec npx nodemon src/index.ts
+CMD npx knex migrate:latest \
+    && npx ts-node src/deploy-commands.ts \
+    && exec npx nodemon src/index.ts
 
 FROM base as build
 
@@ -30,6 +30,6 @@ COPY --chown=node:node package*.json .
 RUN npm ci && npm cache clean --force
 COPY --chown=node:node --from=build /app/dist/ .
 
-CMD npx knex migrate:latest && \
-    node src/deploy-commands.js && \
-    exec node src/index.js
+CMD npx knex migrate:latest \
+    && node src/deploy-commands.js \
+    && exec node src/index.js

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,11 +7,23 @@ USER node
 
 WORKDIR /app
 COPY --chown=node:node package*.json .
-RUN npm install
+RUN npm ci
 COPY --chown=node:node . .
 
-FROM base as prod
+FROM base as build
 
 RUN npm run build
+
+FROM docker.io/node:16-slim as prod
+
+RUN mkdir /app
+RUN chown node:node /app
+
+USER node
+
+WORKDIR /app
+COPY --chown=node:node package*.json .
+RUN npm ci --production
+COPY --chown=node:node --from=build /app/dist/ .
 
 CMD ["npm", "run", "prod"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,10 @@ COPY --chown=node:node package*.json .
 RUN npm ci && npm cache clean --force
 COPY --chown=node:node . .
 
+CMD npx knex migrate:latest && \
+    npx ts-node src/deploy-commands.ts && \
+    exec npx nodemon src/index.ts
+
 FROM base as build
 
 RUN npm run build
@@ -26,4 +30,6 @@ COPY --chown=node:node package*.json .
 RUN npm ci && npm cache clean --force
 COPY --chown=node:node --from=build /app/dist/ .
 
-CMD ["npm", "run", "prod"]
+CMD npx knex migrate:latest && \
+    node src/deploy-commands.js && \
+    exec node src/index.js

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ USER node
 
 WORKDIR /app
 COPY --chown=node:node package*.json .
-RUN npm ci
+RUN npm ci && npm cache clean --force
 COPY --chown=node:node . .
 
 FROM base as build
@@ -23,7 +23,7 @@ USER node
 
 WORKDIR /app
 COPY --chown=node:node package*.json .
-RUN npm ci --production
+RUN npm ci --production && npm cache clean --force
 COPY --chown=node:node --from=build /app/dist/ .
 
 CMD ["npm", "run", "prod"]

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Fill me in
 
 ## Running with Docker
 
+A docker image is available at `docker.io/jcotton42/mrlancer`.
+
 To run this bot populate the environment variables listed in `sample.env` either
 in a `.env` file or through some other mechanism. Then run:
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -15,6 +15,7 @@ services:
       - PGPORT=5432
       - PGPASSWORD
       - PGDATABASE
+    restart: on-failure:5
     command: npm run prod
   postgres:
     image: docker.io/postgres:14

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -15,7 +15,7 @@ services:
       - PGPASSWORD
       - PGDATABASE
     restart: on-failure:5
-    command: npm run prod
+    init: true
   postgres:
     image: docker.io/postgres:14
     environment:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -7,7 +7,6 @@ services:
       dockerfile: Dockerfile
       target: prod
     environment:
-      - NODE_ENV=production
       - DISCORD_BOT_TOKEN
       - DISCORD_CLIENT_ID
       - PGUSER

--- a/docker-compose.swarm.example.yml
+++ b/docker-compose.swarm.example.yml
@@ -2,11 +2,7 @@ version: '3.7'
 
 services:
   lancer:
-    image: 127.0.0.1:5000/lancer
-    build:
-      context: .
-      dockerfile: Dockerfile
-      target: prod
+    image: docker.io/jcotton42/lancerbot:v2
     environment:
       - NODE_ENV=production
       - PGUSER=postgres

--- a/docker-compose.swarm.example.yml
+++ b/docker-compose.swarm.example.yml
@@ -4,7 +4,6 @@ services:
   lancer:
     image: docker.io/jcotton42/lancerbot:v2
     environment:
-      - NODE_ENV=production
       - PGUSER=postgres
       - PGHOST=postgres
       - PGPORT=5432

--- a/docker-compose.swarm.example.yml
+++ b/docker-compose.swarm.example.yml
@@ -2,7 +2,7 @@ version: '3.7'
 
 services:
   lancer:
-    image: docker.io/jcotton42/lancerbot:v2
+    image: docker.io/jcotton42/mrlancer:v1
     environment:
       - PGUSER=postgres
       - PGHOST=postgres
@@ -10,7 +10,7 @@ services:
       - PGDATABASE=lancer
     secrets:
       - source: lancer-config
-        target: /app/dist/src/.env
+        target: /app/src/.env
       - source: lancer-config
         target: /app/.env
     init: true

--- a/docker-compose.swarm.example.yml
+++ b/docker-compose.swarm.example.yml
@@ -13,7 +13,7 @@ services:
         target: /app/dist/src/.env
       - source: lancer-config
         target: /app/.env
-    command: npm run prod
+    init: true
   postgres:
     image: docker.io/postgres:14
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,6 @@ services:
       - ./migrations:/app/migrations
       - ./knexfile.ts:/app/knexfile.ts
     environment:
-      - NODE_ENV=local
       - DISCORD_BOT_TOKEN
       - DISCORD_CLIENT_ID
       - TEST_GUILD_ID
@@ -21,6 +20,7 @@ services:
       - PGPORT=5432
       - PGPASSWORD
       - PGDATABASE
+    restart: on-failure:5
     command: npm run dev
   postgres:
     image: docker.io/postgres:14

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - PGPASSWORD
       - PGDATABASE
     restart: on-failure:5
-    command: npm run dev
+    init: true
   postgres:
     image: docker.io/postgres:14
     environment:

--- a/package.json
+++ b/package.json
@@ -5,8 +5,6 @@
   "main": "index.js",
   "scripts": {
     "build": "tsc",
-    "prod": "knex migrate:latest && node src/deploy-commands.js && node src/index.js",
-    "dev": "knex migrate:latest && ts-node src/deploy-commands.ts && nodemon src/index.ts",
     "register-local": "tsc && cp .env.local ./dist/.env && node dist/deploy-commands.js",
     "start-local": "tsc && cp .env.local ./dist/.env && node dist/index.js",
     "start-prod": "tsc && cp .env ./dist/.env && node dist/index.js",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "build": "tsc",
-    "prod": "knex migrate:latest && node dist/src/deploy-commands.js && node dist/src/index.js",
+    "prod": "knex migrate:latest && node src/deploy-commands.js && node src/index.js",
     "dev": "knex migrate:latest && ts-node src/deploy-commands.ts && nodemon src/index.ts",
     "register-local": "tsc && cp .env.local ./dist/.env && node dist/deploy-commands.js",
     "start-local": "tsc && cp .env.local ./dist/.env && node dist/index.js",


### PR DESCRIPTION
~~Don't merge this just yet, there's some additional tweaks I want to make to the Dockerfile, like setting `NODE_ENV` in the appropriate stages instead of relying on them being set in the Compose file.~~

It's all ready to go!

Things left to do:

- [x] Set `NODE_ENV` in Dockerfile
- [x] Look into whether `npm run prod` properly handles signals. It doesn't seem to https://github.com/nodejs/docker-node/blob/main/docs/BestPractices.md#cmd and `node` itself may need a wrapper `init` process https://github.com/nodejs/docker-node/blob/main/docs/BestPractices.md#handling-kernel-signals. It appears that the latter can be set in the compose and swarm definitions https://docs.docker.com/compose/compose-file/#init.